### PR TITLE
Fixes issue with multiple browser sync instances

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -2,9 +2,8 @@
 
 import gulp from 'gulp';
 import path from 'path';
+import webpack from 'webpack-stream';
 const browserSync = require('browser-sync').create();
-// import serve from 'browser-sync';
-// import sync from 'run-sequence';
 
 const reload = () => browserSync.reload();
 const root = 'client';
@@ -27,7 +26,13 @@ const paths = {
   output: root
 };
 
-gulp.task('reload', (done) => {
+gulp.task('webpack', () => {
+  return gulp.src(paths.entry)
+    .pipe(webpack(require('./webpack.config')))
+    .pipe(gulp.dest(paths.output));
+});
+
+gulp.task('reload', ['webpack'], (done) => {
   reload();
   done();
 });

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,21 +1,22 @@
 'use strict';
 
-import gulp     from 'gulp';
-import path     from 'path';
-import sync     from 'run-sequence';
-import serve    from 'browser-sync';
+import gulp from 'gulp';
+import path from 'path';
+const browserSync = require('browser-sync').create();
+// import serve from 'browser-sync';
+// import sync from 'run-sequence';
 
-let reload = () => serve.reload();
-let root = 'client';
+const reload = () => browserSync.reload();
+const root = 'client';
 
 // helper method for resolving paths
-let resolveToApp = (glob) => {
+const resolveToApp = (glob) => {
   glob = glob || '';
   return path.join(root, 'app', glob); // app/{glob}
 };
 
 // map of all paths
-let paths = {
+const paths = {
   js: resolveToApp('**/*!(.spec.js).js'), // exclude spec files
   styl: resolveToApp('**/*.styl'), // stylesheets
   html: [
@@ -26,19 +27,22 @@ let paths = {
   output: root
 };
 
+gulp.task('reload', (done) => {
+  reload();
+  done();
+});
+
 gulp.task('serve', () => {
-  serve({
+  browserSync.init({
     port: process.env.PORT || 3000,
-    open: false,
+    open: true,
     server: { baseDir: root }
   });
 });
 
-gulp.task('watch', () => {
-  let allPaths = [].concat([paths.js], paths.html, [paths.styl]);
-  gulp.watch(allPaths, [reload]);
+gulp.task('watch', ['serve'], () => {
+  const allPaths = [].concat([paths.js], paths.html, [paths.styl]);
+  gulp.watch(allPaths, ['reload']);
 });
 
-gulp.task('default', (done) => {
-  sync('serve', 'watch', done);
-});
+gulp.task('default', ['watch']);


### PR DESCRIPTION
HI, I noticed an issue with BrowserSync upon changes to files. I would receive an error indicating a potential memory leak with multiple instances of browserSync being unecessarily created. Below is the error message I was receiving:

> [error] You tried to start Browsersync twice! To create multiple instances, use browserSync.create().init()

This PR just simply modifies the gulpfile a bit by only calling reload and not starting a new browserSync instance on changes of files.
